### PR TITLE
(k8s)Builder: Updated builder function for pod and container

### DIFF
--- a/kubernetes/container/build.go
+++ b/kubernetes/container/build.go
@@ -137,3 +137,20 @@ func (b *Builder) WithEnvsNew(envs []corev1.EnvVar) *Builder {
 	b.con.object.Env = newenvs
 	return b
 }
+
+// WithPortsNew sets ports of the container
+func (b *Builder) WithPortsNew(ports []corev1.ContainerPort) *Builder {
+	if len(ports) == 0 {
+		b.errors = append(
+			b.errors,
+			errors.New("failed to build container object: missing ports"),
+		)
+		return b
+	}
+
+	newports := []corev1.ContainerPort{}
+	newports = append(newports, ports...)
+
+	b.con.object.Ports = newports
+	return b
+}

--- a/kubernetes/pod/build.go
+++ b/kubernetes/pod/build.go
@@ -79,6 +79,19 @@ func (b *Builder) WithServiceAccountName(serviceaccountname string) *Builder {
 	return b
 }
 
+// WithRestartPolicy sets the restartpolicy field of Pod spec with provided value
+func (b *Builder) WithRestartPolicy(restartpolicy corev1.RestartPolicy) *Builder {
+	if len(restartpolicy) == 0 {
+		b.errs = append(
+			b.errs,
+			errors.New("failed to build Pod object: missing Pod restartpolicy"),
+		)
+		return b
+	}
+	b.pod.object.Spec.RestartPolicy = restartpolicy
+	return b
+}
+
 // WithContainerBuilder adds a container to this pod object.
 //
 // NOTE:


### PR DESCRIPTION
This commit will do the following changes:

- Add `WithRestartPolicy()` for **pod** and  `WithPortsNew()` for **container**.
- WithRestartPolicy sets the restartpolicy field of Pod spec with the provided value.
- WithPortsNew sets ports of the container

Signed-off-by: Amit Bhatt <amitbhatt818@gmail.com>