### PR TITLE
(enhancement)builder: add nodeselector to the builder functions for addition into podTemplateSpec

### DIFF
--- a/kubernetes/podtemplatespec/podtemplatespec.go
+++ b/kubernetes/podtemplatespec/podtemplatespec.go
@@ -100,6 +100,58 @@ func (b *Builder) WithAnnotationsNew(annotations map[string]string) *Builder {
 	return b
 }
 
+
+// WithNodeSelector merges the nodeselectors if present
+// with the provided arguments
+func (b *Builder) WithNodeSelector(nodeselectors map[string]string) *Builder {
+	if len(nodeselectors) == 0 {
+		b.errs = append(
+			b.errs,
+			errors.New(
+				"failed to build podtemplatespec object: missing nodeselectors",
+			),
+		)
+		return b
+	}
+
+	if b.podtemplatespec.Object.Spec.NodeSelector == nil {
+		return b.WithNodeSelectorNew(nodeselectors)
+	}
+
+	for key, value := range nodeselectors {
+		b.podtemplatespec.Object.Spec.NodeSelector[key] = value
+	}
+	return b
+}
+
+// WithNodeSelectorNew resets the nodeselector field of podtemplatespec
+// with provided arguments
+func (b *Builder) WithNodeSelectorNew(nodeselectors map[string]string) *Builder {
+	if len(nodeselectors) == 0 {
+		b.errs = append(
+			b.errs,
+			errors.New(
+				"failed to build podtemplatespec object: missing nodeselectors",
+			),
+		)
+		return b
+	}
+
+	// copy of original map
+	newnodeselectors := map[string]string{}
+	for key, value := range nodeselectors {
+		newnodeselectors[key] = value
+	}
+
+	// override
+	b.podtemplatespec.Object.Spec.NodeSelector = newnodeselectors
+	return b
+}
+
+
+
+
+
 // WithLabels merges existing labels if any
 // with the ones that are provided here
 func (b *Builder) WithLabels(labels map[string]string) *Builder {


### PR DESCRIPTION
- Adds a builder function for setting the nodeSelector in a podTemplateSpec. 
- Added to support of issue https://github.com/litmuschaos/litmus/issues/1240

Signed-off-by: ksatchit <karthik.s@mayadata.io>